### PR TITLE
Feat/update typedresult

### DIFF
--- a/src/DEPLOY.Cachorro.Api/DEPLOY.Cachorro.Api.csproj
+++ b/src/DEPLOY.Cachorro.Api/DEPLOY.Cachorro.Api.csproj
@@ -23,7 +23,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />
-		<PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.1" />
+		<PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.4.0" />
 		<PackageReference Include="Azure.Identity" Version="1.11.4" />
 		<PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
 		<PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />

--- a/src/DEPLOY.Cachorro.MinimalApi/DEPLOY.Cachorro.MinimalApi.csproj
+++ b/src/DEPLOY.Cachorro.MinimalApi/DEPLOY.Cachorro.MinimalApi.csproj
@@ -3,10 +3,10 @@
 	<PropertyGroup>
 		<TargetFramework>net8.0</TargetFramework>
 		<Nullable>enable</Nullable>
-		<NoWarn>$(NoWarn);1591</NoWarn>
+		<!--<NoWarn>$(NoWarn);1591</NoWarn>
 		<NoWarn>$(NoWarn);8604</NoWarn>
 		<NoWarn>$(NoWarn);8603</NoWarn>
-		<NoWarn>$(NoWarn);8602</NoWarn>
+		<NoWarn>$(NoWarn);8602</NoWarn>-->
 		<UserSecretsId>CachorroAPI_MVP</UserSecretsId>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 		<DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>

--- a/src/DEPLOY.Cachorro.MinimalApi/DEPLOY.Cachorro.MinimalApi.csproj
+++ b/src/DEPLOY.Cachorro.MinimalApi/DEPLOY.Cachorro.MinimalApi.csproj
@@ -23,7 +23,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />
-		<PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.1" />
+		<PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.4.0" />
 		<PackageReference Include="Azure.Identity" Version="1.11.4" />
 		<PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
 		<PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />

--- a/src/DEPLOY.Cachorro.MinimalApi/Endpoints/v1/AdocoesEndpoints.cs
+++ b/src/DEPLOY.Cachorro.MinimalApi/Endpoints/v1/AdocoesEndpoints.cs
@@ -68,7 +68,7 @@ namespace DEPLOY.Cachorro.MinimalApi.Endpoints.v1
 
                 if (item?.Count() > 0)
                 {
-                    return TypedResults.UnprocessableEntity(item);
+                    return Results.UnprocessableEntity(item);
                 }
 
                 return TypedResults.Ok();
@@ -87,7 +87,7 @@ namespace DEPLOY.Cachorro.MinimalApi.Endpoints.v1
 
                 if (item?.Count() > 0)
                 {
-                    return TypedResults.UnprocessableEntity(item);
+                    return Results.UnprocessableEntity(item);
                 }
 
                 return TypedResults.Ok();

--- a/src/DEPLOY.Cachorro.MinimalApi/Endpoints/v1/CachorroEndpoints.cs
+++ b/src/DEPLOY.Cachorro.MinimalApi/Endpoints/v1/CachorroEndpoints.cs
@@ -149,7 +149,7 @@ namespace DEPLOY.Cachorro.MinimalApi.Endpoints.v1
 
                 if (items == null)
                 {
-                    return TypedResults.NotFound();
+                    return Results.NotFound();
                 }
 
                 return TypedResults.Ok(items);
@@ -166,14 +166,14 @@ namespace DEPLOY.Cachorro.MinimalApi.Endpoints.v1
                                 cancellationToken);
 
                 if (item?.Erros.Count() > 0)
-                    return TypedResults.UnprocessableEntity(item.Erros);
+                    return Results.UnprocessableEntity(item.Erros);
 
                 var apiVersion = request.RouteValues["apiVersion"];
                 var scheme = request.Scheme;
                 var host = request.Host;
                 var location = new Uri($"{scheme}{Uri.SchemeDelimiter}{host}/api/v{apiVersion}/cachorros/{item?.Id}");
 
-                return Results.Created(location, item);
+                return TypedResults.Created(location, item);
             }
 
             async Task<IResult> DeleteCachorroAsync(
@@ -186,7 +186,7 @@ namespace DEPLOY.Cachorro.MinimalApi.Endpoints.v1
                                 cancellationToken);
 
                 if (item)
-                    return TypedResults.NoContent();
+                    return Results.NoContent();
 
                 return TypedResults.NotFound();
             }
@@ -199,7 +199,7 @@ namespace DEPLOY.Cachorro.MinimalApi.Endpoints.v1
             {
                 if (id != cachorroDto.Id)
                 {
-                    return TypedResults.UnprocessableEntity();
+                    return Results.UnprocessableEntity();
                 }
 
                 var item = await cachorroAppServices.UpdateAsync(
@@ -207,7 +207,7 @@ namespace DEPLOY.Cachorro.MinimalApi.Endpoints.v1
                     cachorroDto,
                     cancellationToken);
 
-                return !item.Any() ? TypedResults.NoContent()
+                return !item.Any() ? Results.NoContent()
                           : TypedResults.UnprocessableEntity(item);
             }
 
@@ -219,7 +219,7 @@ namespace DEPLOY.Cachorro.MinimalApi.Endpoints.v1
                     c => c.Adotado,
                     cancellationToken);
 
-                return items?.Count() > 0 ? TypedResults.Ok(items) : TypedResults.NoContent();
+                return items?.Count() > 0 ? Results.Ok(items) : TypedResults.NoContent();
             }
 
             async Task<IResult> ListAllCachorrosParaAdotarAsync(
@@ -230,7 +230,7 @@ namespace DEPLOY.Cachorro.MinimalApi.Endpoints.v1
                     c => !c.Adotado,
                     cancellationToken);
 
-                return items?.Count() > 0 ? TypedResults.Ok(items) : TypedResults.NoContent();
+                return items?.Count() > 0 ? Results.Ok(items) : TypedResults.NoContent();
             }
         }
     }

--- a/src/DEPLOY.Cachorro.MinimalApi/Endpoints/v1/TutorEndpoints.cs
+++ b/src/DEPLOY.Cachorro.MinimalApi/Endpoints/v1/TutorEndpoints.cs
@@ -67,7 +67,7 @@ namespace DEPLOY.Cachorro.MinimalApi.Endpoints.v1
                 {
                     var items = await tutorAppService.GetByIdAsync(id, cancellationToken);
 
-                    return items == null ? TypedResults.NoContent() : TypedResults.Ok(items);
+                    return items == null ? Results.NoContent() : TypedResults.Ok(items);
                 }
 
                 return await ListAllAsync(tutorAppService);
@@ -96,7 +96,7 @@ namespace DEPLOY.Cachorro.MinimalApi.Endpoints.v1
                         var item = await tutorAppService.InsertAsync(tutorDto, cancellationToken);
 
                         if (item.Erros.Any())
-                            return TypedResults.UnprocessableEntity(item.Erros);
+                            return Results.UnprocessableEntity(item.Erros);
 
                         var apiVersion = request.RouteValues["apiVersion"];
 
@@ -133,7 +133,7 @@ namespace DEPLOY.Cachorro.MinimalApi.Endpoints.v1
                     var item = await tutorAppService.UpdateAsync(id, tutorDto, cancellationToken);
 
                     if (item.Any())
-                        return TypedResults.UnprocessableEntity(item);
+                        return Results.UnprocessableEntity(item);
 
                     return TypedResults.Ok(item);
                 }
@@ -162,7 +162,7 @@ namespace DEPLOY.Cachorro.MinimalApi.Endpoints.v1
                 {
                     var item = await tutorAppService.DeleteAsync(id, cancellationToken);
 
-                    return item ? TypedResults.NoContent() : TypedResults.NotFound();
+                    return item ? Results.NoContent() : TypedResults.NotFound();
                 }
 
                 return await DeleteTutorAsync();
@@ -178,7 +178,6 @@ namespace DEPLOY.Cachorro.MinimalApi.Endpoints.v1
                     Description = "Operação para deletar tutor por id",
                     Tags = new List<OpenApiTag> { new() { Name = "Tutores" } }
                 });
-
         }
     }
 }


### PR DESCRIPTION
This pull request introduces changes to the `DEPLOY.Cachorro.MinimalApi` project, focusing on replacing the use of `TypedResults` with `Results` for consistency and simplifying the `csproj` file by commenting out certain `NoWarn` directives. The most important changes are grouped below:

### API Response Consistency:
* Replaced `TypedResults.UnprocessableEntity` with `Results.UnprocessableEntity` in multiple methods across `AdocoesEndpoints`, `CachorroEndpoints`, and `TutorEndpoints` for uniformity. [[1]](diffhunk://#diff-b8023562ad9df3ca87a7001550f0226bdd2de6523337f940bd070b902a65b47cL71-R71) [[2]](diffhunk://#diff-b8023562ad9df3ca87a7001550f0226bdd2de6523337f940bd070b902a65b47cL90-R90) [[3]](diffhunk://#diff-0cac15180a718c574a0ce595ff333ca73a53371156b300c206fbb2ee1a5a8f4aL169-R176) [[4]](diffhunk://#diff-0cac15180a718c574a0ce595ff333ca73a53371156b300c206fbb2ee1a5a8f4aL202-R210) [[5]](diffhunk://#diff-5908eda77fa5d72c9d0892bf69a89683c87be3e132ff7eb6a144434e52016187L99-R99) [[6]](diffhunk://#diff-5908eda77fa5d72c9d0892bf69a89683c87be3e132ff7eb6a144434e52016187L136-R136)
* Replaced `TypedResults.NotFound` with `Results.NotFound` in methods like `GetByIdAsync` and `DeleteCachorroAsync` in `CachorroEndpoints`, and `DeleteTutorAsync` in `TutorEndpoints`. [[1]](diffhunk://#diff-0cac15180a718c574a0ce595ff333ca73a53371156b300c206fbb2ee1a5a8f4aL152-R152) [[2]](diffhunk://#diff-0cac15180a718c574a0ce595ff333ca73a53371156b300c206fbb2ee1a5a8f4aL189-R189) [[3]](diffhunk://#diff-5908eda77fa5d72c9d0892bf69a89683c87be3e132ff7eb6a144434e52016187L165-R165)
* Replaced `TypedResults.NoContent` with `Results.NoContent` in methods such as `DeleteCachorroAsync`, `UpdateCachorroAsync`, and `ListAllAsync` in `TutorEndpoints`. [[1]](diffhunk://#diff-0cac15180a718c574a0ce595ff333ca73a53371156b300c206fbb2ee1a5a8f4aL189-R189) [[2]](diffhunk://#diff-0cac15180a718c574a0ce595ff333ca73a53371156b300c206fbb2ee1a5a8f4aL202-R210) [[3]](diffhunk://#diff-5908eda77fa5d72c9d0892bf69a89683c87be3e132ff7eb6a144434e52016187L70-R70)
* Updated conditional return statements to replace `TypedResults.Ok` with `Results.Ok` in methods like `ListAllCachorrosAdotadosAsync` and `ListAllCachorrosParaAdotarAsync`. [[1]](diffhunk://#diff-0cac15180a718c574a0ce595ff333ca73a53371156b300c206fbb2ee1a5a8f4aL222-R222) [[2]](diffhunk://#diff-0cac15180a718c574a0ce595ff333ca73a53371156b300c206fbb2ee1a5a8f4aL233-R233)

### Project File Simplification:
* Commented out specific `NoWarn` directives in the `csproj` file, potentially to reevaluate or clean up warnings management.